### PR TITLE
Fix powerline active colors

### DIFF
--- a/github-theme.el
+++ b/github-theme.el
@@ -992,8 +992,8 @@ Also bind `class' to ((class color) (min-colors 89))."
 ;;;;; perspective
    `(persp-selected-face ((t (:foreground ,github-yellow-2 :inherit mode-line))))
 ;;;;; powerline
-   `(powerline-active1 ((t (:background ,github-bg-05 :inherit mode-line))))
-   `(powerline-active2 ((t (:background ,github-bg+2 :inherit mode-line))))
+   `(powerline-active1 ((t (:background ,github-red :inherit mode-line))))
+   `(powerline-active2 ((t (:background ,github-blue+1 :inherit mode-line))))
    `(powerline-inactive1 ((t (:background ,github-bg+1 :inherit mode-line-inactive))))
    `(powerline-inactive2 ((t (:background ,github-bg+3 :inherit mode-line-inactive))))
 ;;;;; proofgeneral


### PR DESCRIPTION
This PR fixes the powerline active colors.

Before:
<img width="955" alt="github-theme-powerline1" src="https://cloud.githubusercontent.com/assets/8885691/21539237/36e18a48-cda5-11e6-852e-745a80ed03e7.png">

After:
<img width="957" alt="github-theme-powerline2" src="https://cloud.githubusercontent.com/assets/8885691/21539243/43e30e06-cda5-11e6-8885-162179d72de4.png">

