### PR TITLE
Add org-agenda-clocking face

### DIFF
--- a/github-theme.el
+++ b/github-theme.el
@@ -897,6 +897,8 @@ Also bind `class' to ((class color) (min-colors 89))."
    `(neo-vc-missing-face ((t (:foreground ,github-text))))
    `(neo-vc-ignored-face ((t (:foreground ,github-text))))
 ;;;;; org-mode
+   `(org-agenda-clocking
+     ((t (:bold t :background ,github-highlight))) t)
    `(org-agenda-date-today
      ((t (:foreground ,github-text :slant italic :weight bold))) t)
    `(org-agenda-structure


### PR DESCRIPTION
This shows in the agenda for the currently clocked in task.

Previously it had a white background, which meant you couldn't tell what task
was clocked in.

Here's a screenshot with the new face added:
![screenshot_2017-01-11_09-33-48](https://cloud.githubusercontent.com/assets/19060/21857019/3ab239e2-d7e1-11e6-93fd-445c96db49fd.png)
